### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "pointclouds"
   ],
   "description": "Converts KITTI 3D format to Supervisely pointcloud format",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "docker_image": "supervisely/import-export:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "gui_template": "src/gui.html",

--- a/config.json
+++ b/config.json
@@ -1,9 +1,12 @@
 {
   "name": "Import KITTI 3D",
   "type": "app",
-  "categories": ["import", "pointclouds"],
+  "categories": [
+    "import",
+    "pointclouds"
+  ],
   "description": "Converts KITTI 3D format to Supervisely pointcloud format",
-  "docker_image": "supervisely/import-export:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "gui_template": "src/gui.html",

--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
   "categories": ["import", "pointclouds"],
   "description": "Converts KITTI 3D format to Supervisely pointcloud format",
   "docker_image": "supervisely/import-export:6.73.564",
-  "instance_version": "6.10.0",
+  "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "gui_template": "src/gui.html",
   "task_location": "workspace_tasks",

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "type": "app",
   "categories": ["import", "pointclouds"],
   "description": "Converts KITTI 3D format to Supervisely pointcloud format",
-  "docker_image": "supervisely/import-export:6.73.147",
+  "docker_image": "supervisely/import-export:6.73.564",
   "instance_version": "6.10.0",
   "main_script": "src/main.py",
   "gui_template": "src/gui.html",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,1 @@
 supervisely==6.73.564
-# supervisely[apps]==6.73.564
-# open3d==0.13.0
-# scikit-image==0.18.3

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-supervisely==6.73.147
-# supervisely[apps]==6.73.15
+supervisely==6.73.564
+# supervisely[apps]==6.73.564
 # open3d==0.13.0
 # scikit-image==0.18.3

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # cuda:11.1-cudnn8-runtime-ubuntu20.04 + py3.8 + opencv + other bacis CV packages
 # learn more here: https://github.com/supervisely/supervisely/blob/master/base_images/py/Dockerfile
-FROM supervisely/base-py-sdk:6.1.104
+FROM supervisely/base-py-sdk:6.73.564
 
-RUN pip install supervisely==6.1.104
+RUN pip install supervisely==6.73.564
 RUN python -m pip install open3d==0.13.0
 RUN pip install scikit-image==0.18.3


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
